### PR TITLE
Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_script:
   - npm install --prefix server
   - npm install --prefix client
   - mv server/config/config-ci.js server/config/config.js
-  - psql -c 'create database easypick-development;' -U postgres
+  - psql -c 'create database "easypick-development";' -U postgres
 script: npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+services:
+  - postgresql
 node_js:
   - "7"
 before_script:
@@ -7,4 +9,5 @@ before_script:
   - npm install --prefix server
   - npm install --prefix client
   - mv server/config/config-ci.js server/config/config.js
+  - psql -c 'create database easypick-development;' -U postgres
 script: npm run ci

--- a/src/server/config/config-ci.js
+++ b/src/server/config/config-ci.js
@@ -3,31 +3,13 @@ var path = require('path'),
     env = process.env.NODE_ENV || 'development';
 
 var config = {
-  development: {
-    root: rootPath,
-    app: {
-      name: 'easypick'
-    },
-    port: process.env.PORT || 3001,
-    db: 'mysql://root@localhost/easypick-development'
-  },
-
   test: {
     root: rootPath,
     app: {
       name: 'easypick'
     },
     port: process.env.PORT || 3001,
-    db: 'mysql://root@localhost/easypick-test'
-  },
-
-  production: {
-    root: rootPath,
-    app: {
-      name: 'easypick'
-    },
-    port: process.env.PORT || 3001,
-    db: 'mysql://root@localhost/easypick-production'
+    db: 'postgres://postgres@localhost/easypick-test'
   }
 };
 

--- a/src/server/config/config-example.js
+++ b/src/server/config/config-example.js
@@ -9,7 +9,7 @@ var config = {
       name: 'easypick'
     },
     port: process.env.PORT || 3001,
-    db: 'mysql://root:123456@localhost/easypick-development'
+    db: 'postgres://root:123456@localhost/easypick-development'
   },
 
   test: {
@@ -18,7 +18,7 @@ var config = {
       name: 'easypick'
     },
     port: process.env.PORT || 3001,
-    db: 'mysql://root:123456@localhost/easypick-test'
+    db: 'postgres://root:123456@localhost/easypick-test'
   },
 
   production: {
@@ -27,7 +27,7 @@ var config = {
       name: 'easypick'
     },
     port: process.env.PORT || 3001,
-    db: 'mysql://root:123456@localhost/easypick-production'
+    db: 'postgres://root:123456@localhost/easypick-production'
   }
 };
 

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -20,7 +20,8 @@
     "glob": "^6.0.4",
     "method-override": "^2.3.8",
     "morgan": "^1.8.1",
-    "mysql": "^2.13.0",
+    "pg": "^6.2.2",
+    "pg-hstore": "^2.3.2",
     "sequelize": "^3.30.4",
     "serve-favicon": "^2.4.2"
   },


### PR DESCRIPTION
This PR switches us over to Postgres, the database of choice on Heroku. It's highly recommended to switch to Postgres on your dev machine (although technically you don't have to).

To do this:
- Install postgres. Guides: [Ubuntu](https://tecadmin.net/install-postgresql-server-on-ubuntu/), [Windows](https://www.labkey.org/Documentation/wiki-page.view?name=installPostgreSQLWindows), [OSX](https://launchschool.com/blog/how-to-install-postgresql-on-a-mac)
- Create a database called `easypick-development`. On Ubuntu at least, you can do this with `createdb easypick-development`. YMMV.
- Optionally, create a postgres user. Postgres should have automatically created one with your username on install, and you can use that in your `config.js` if you want.