### PR TITLE
Fix Respond page

### DIFF
--- a/client/src/Components/Respond/Respond.js
+++ b/client/src/Components/Respond/Respond.js
@@ -125,7 +125,7 @@ class Respond extends Component {
 
     var data = getFormData($('#response-form'));
     data.schedule = this.refs.schedule.value();
-    data.location_preferences = this.refs.location.value();
+    data.locationPreferences = this.refs.location.value();
 
     $.ajax({
         type: 'POST',
@@ -134,7 +134,7 @@ class Respond extends Component {
     })
     .done(function(data) {
       $('#response-form')[0].reset();
-      $('#title').hide();
+      $('#title, #location-display').hide();
       $('#response-row').hide();
       $('#confirmation-row').fadeIn();
     })

--- a/server/app/controllers/response.js
+++ b/server/app/controllers/response.js
@@ -3,27 +3,30 @@ var express = require('express'),
   db = require('../models');
 
 module.exports = function (app) {
-  app.use('/api/response/', router);
+  app.use('/response', router);
 };
 
 router.post('/create', function (req, res, next) {
-  try {
-    JSON.parse(req.body.schedule);
-  } catch (e) {
-    res.status(500).json({
-      success: false
-    });
-    return;
+  if (typeof req.body.schedule === 'string') {
+    try {
+      JSON.parse(req.body.schedule);
+    } catch (e) {
+      return res.status(500).json({
+        success: false
+      });
+    }
   }
 
-  try {
-    JSON.parse(req.body.locationPreferences)
-  } catch (e) {
-    res.status(500).json({
-      success: false
-    });
-    return;
+  if (typeof req.body.locationPreferences === 'string') {
+    try {
+      JSON.parse(req.body.locationPreferences);
+    } catch (e) {
+      return res.status(500).json({
+        success: false
+      });
+    }
   }
+
   db.Response.create({
     name: req.body.name,
     email: req.body.email,

--- a/server/test/app/controllers/response.js
+++ b/server/test/app/controllers/response.js
@@ -44,7 +44,7 @@ describe('response routes', function() {
 
     it('should succeed when everything is supplied', function(done) {
       chai.request(app)
-        .post('/api/response/create')
+        .post('/response/create')
         .send({
           name: 'Meeting Name',
           email: 'fake@email.com',
@@ -62,7 +62,7 @@ describe('response routes', function() {
 
     it('should fail when schedule is invalid', function(done) {
       chai.request(app)
-        .post('/api/response/create')
+        .post('/response/create')
         .send({
           name: 'Meeting Name',
           email: 'fake@email.com',
@@ -80,7 +80,7 @@ describe('response routes', function() {
 
     it('should fail when locationPreferences is invalid', function(done) {
       chai.request(app)
-        .post('/api/response/create')
+        .post('/response/create')
         .send({
           name: 'Meeting Name',
           email: 'fake@email.com',


### PR DESCRIPTION
Resolves three issues:
- The param names of the respond page didn't match with the ones the server expected
- The general location map did not disappear on submit
- There was a routing issue in production with the /api being duplicated

Closes #23